### PR TITLE
hotfix/1.0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "waynestate/news-api-php",
     "description": "Connector for News API",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "license": "MIT",
     "authors": [
         {

--- a/src/News.php
+++ b/src/News.php
@@ -161,7 +161,9 @@ class News
             $payload_response = json_decode($response->getBody()->getContents(), true);
 
             if (isset($payload_response['errors'])) {
-                throw new Exception($payload_response['errors']);
+                $error = current($payload_response['errors']);
+
+                throw new \Exception($error['message'], $error['code']);
             }
 
             $payload = $payload_response['data'];


### PR DESCRIPTION
* Set the correct error information while throwing the exception
* Use `\Exception` since this package does not have his own exception object