### PR TITLE
Hotfix/1.0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "waynestate/news-api-php",
     "description": "Connector for News API",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "license": "MIT",
     "authors": [
         {

--- a/src/News.php
+++ b/src/News.php
@@ -5,7 +5,6 @@ use GuzzleHttp\Exception\TransferException;
 
 class News
 {
-
     /** @var  string */
     protected $developer_key;
 
@@ -93,6 +92,7 @@ class News
         // Create the payload file
         if (!is_file($this->payload_file)) {
             file_put_contents($this->payload_file, '');
+            chmod($this->payload_file, 02770);
         }
     }
 
@@ -118,7 +118,9 @@ class News
             try {
                 $payload = $this->getPayload();
             } catch (TransferException $e) {
-                echo 'Guzzle Error: ' . $e->getMessage();
+                error_log($e->getMessage(), 0);
+            } catch(\Exception $e) {
+                error_log($e->getMessage(), 0);
             }
 
             // Write payload to cache
@@ -161,9 +163,7 @@ class News
             $payload_response = json_decode($response->getBody()->getContents(), true);
 
             if (isset($payload_response['errors'])) {
-                $error = current($payload_response['errors']);
-
-                throw new \Exception($error['message'], $error['code']);
+                throw new \Exception(print_r($payload_response['errors'], true));
             }
 
             $payload = $payload_response['data'];
@@ -215,7 +215,7 @@ class News
                 'verify' => false
             ]);
         } catch (TransferException $e) {
-            echo 'Guzzle Error: ' . $e->getMessage();
+            error_log($e->getMessage(), 0);
         }
 
         // If successful return the request
@@ -224,14 +224,10 @@ class News
 
             // Check for errors
             if (isset($request_response['errors'])) {
-                // Set the error response
-                $request = $request_response;
-            } else {
-                // Set the data response
-                $request = $request_response;
+                error_log(print_r($request_response['errors'], true), 0);
             }
 
-            return $request;
+            return $request_response;
         }
 
         return false;

--- a/src/News.php
+++ b/src/News.php
@@ -118,9 +118,9 @@ class News
             try {
                 $payload = $this->getPayload();
             } catch (TransferException $e) {
-                throw new $e($e->getMessage());
+                throw $e;
             } catch(\Exception $e) {
-                throw new $e($e->getMessage());
+                throw $e;
             }
 
             // Write payload to cache
@@ -215,7 +215,7 @@ class News
                 'verify' => false
             ]);
         } catch (TransferException $e) {
-            error_log($e->getMessage(), 0);
+            throw $e;
         }
 
         // If successful return the request

--- a/src/News.php
+++ b/src/News.php
@@ -118,9 +118,9 @@ class News
             try {
                 $payload = $this->getPayload();
             } catch (TransferException $e) {
-                error_log($e->getMessage(), 0);
+                throw new $e($e->getMessage());
             } catch(\Exception $e) {
-                error_log($e->getMessage(), 0);
+                throw new $e($e->getMessage());
             }
 
             // Write payload to cache


### PR DESCRIPTION
Leaving open for discussion in another thread

* Update the permissions of the payload file on setup
* Re-throw the exceptions instead of echoing them
* If the API returns errors in the JSON response log those errors but return the 200 response still so the app can handle it however it wants.
* Simplify the `$request_response` return. It was doing an unnecessary conditional where the if and else was doing the same thing